### PR TITLE
fixes an issue with assembly inspection changes in .net 5.

### DIFF
--- a/NUnit.Commander/DotNetCoreTests/DotNetCoreTests.csproj
+++ b/NUnit.Commander/DotNetCoreTests/DotNetCoreTests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/NUnit.Commander/NUnit.Commander/Commander.cs
+++ b/NUnit.Commander/NUnit.Commander/Commander.cs
@@ -275,8 +275,8 @@ namespace NUnit.Commander
                 if (DotNetRuntimes.Contains(e.EventEntry.Event.TestRunner))
                 {
                     // disconnect from the server, and wait for a new connection to appear
-                    Debug.WriteLine($"Waiting for another server connection...");
-                    _console.WriteLine($"Waiting for another server connection...");
+                    // if there is a long timeout here, the application will hang for a while
+                    _console.WriteLine($"Reconnecting to dotnet test extension ({_configuration.ConnectTimeoutSeconds}s timeout)...");
 
                     // launch another connection request, but in a non-blocking task as we are currently in an i/o lock
                     // could alternatively create a connection queue
@@ -588,7 +588,7 @@ namespace NUnit.Commander
                     {
                         // fix for older versions of nunit
                         e.Event.Event = EventNames.StartAssembly;
-                        Debug.WriteLine($"StartAssembly: {e.Event.TestSuite}");
+                        //Debug.WriteLine($"StartAssembly: {e.Event.TestSuite}");
                         _activeAssemblies.Add(new EventEntry(e));
                     }
                     else

--- a/NUnit.Commander/NUnit.Commander/IO/PortableExecutionHelper.cs
+++ b/NUnit.Commander/NUnit.Commander/IO/PortableExecutionHelper.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using System.Runtime.Versioning;
 
 namespace NUnit.Commander.IO
@@ -20,21 +23,102 @@ namespace NUnit.Commander.IO
 
             try
             {
-                var assembly = Assembly.LoadFrom(filename);
-                var targetFrameworkAttribute = assembly.CustomAttributes.Where(x => x.AttributeType.Equals(typeof(TargetFrameworkAttribute))).FirstOrDefault();
-                if (targetFrameworkAttribute != null)
-                {
-                    var targetFramework = targetFrameworkAttribute.ConstructorArguments.First().Value.ToString();
-                    if (targetFramework?.StartsWith(".NETFramework") ?? false)
-                        return FrameworkType.DotNetFramework;
-                    else if (targetFramework?.StartsWith(".NETCoreApp") ?? false)
-                        return FrameworkType.DotNetCore;
-                }
+                using var fileStream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var peReader = new PEReader(fileStream);
+                var reader = peReader.GetMetadataReader();
+                var assembly = reader.GetAssemblyDefinition();
+                var targetFramework = GetTargetFrameworkFromAssembly(reader, assembly);
+                if (targetFramework?.StartsWith(".NETFramework", StringComparison.InvariantCultureIgnoreCase) ?? false)
+                    return FrameworkType.DotNetFramework;
+                else if (targetFramework?.StartsWith(".NETCoreApp", StringComparison.InvariantCultureIgnoreCase) ?? false)
+                    return FrameworkType.DotNetCore;
             }
-            catch (FileLoadException)
+            catch (Exception ex)
             {
+                Console.WriteLine($"Exception trying to load assembly '{filename}'! {ex.GetType()}: {ex.GetBaseException().Message}");
             }
             return FrameworkType.Unknown;
+        }
+
+        /// <summary>
+        /// Get the parameter values of a custom attribute
+        /// </summary>
+        /// <param name="customAttribute"></param>
+        /// <param name="reader"></param>
+        /// <returns></returns>
+        private static ImmutableArray<string> GetParameterValues(this CustomAttribute customAttribute, MetadataReader reader)
+        {
+            if (customAttribute.Constructor.Kind != HandleKind.MemberReference) throw new InvalidOperationException();
+
+            var ctor = reader.GetMemberReference((MemberReferenceHandle)customAttribute.Constructor);
+            var provider = new StringParameterValueTypeProvider(reader, customAttribute.Value);
+            var signature = ctor.DecodeMethodSignature(provider, null);
+            return signature.ParameterTypes;
+        }
+
+        /// <summary>
+        /// Provider for parsing string parameter values
+        /// </summary>
+        private sealed class StringParameterValueTypeProvider : ISignatureTypeProvider<string, object>
+        {
+            private readonly BlobReader valueReader;
+
+            public StringParameterValueTypeProvider(MetadataReader reader, BlobHandle value)
+            {
+                Reader = reader;
+                valueReader = reader.GetBlobReader(value);
+
+                var prolog = valueReader.ReadUInt16();
+                if (prolog != 1) throw new BadImageFormatException("Invalid custom attribute prolog.");
+            }
+
+            public MetadataReader Reader { get; }
+
+            public string GetArrayType(string elementType, ArrayShape shape) => "";
+            public string GetByReferenceType(string elementType) => "";
+            public string GetFunctionPointerType(MethodSignature<string> signature) => "";
+            public string GetGenericInstance(string genericType, ImmutableArray<string> typestrings) => "";
+            public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments) { throw new NotImplementedException(); }
+            public string GetGenericMethodParameter(int index) => "";
+            public string GetGenericMethodParameter(object genericContext, int index) { throw new NotImplementedException(); }
+            public string GetGenericTypeParameter(int index) => string.Empty;
+            public string GetGenericTypeParameter(object genericContext, int index) { throw new NotImplementedException(); }
+            public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => "";
+            public string GetPinnedType(string elementType) => string.Empty;
+            public string GetPointerType(string elementType) => string.Empty;
+            public string GetPrimitiveType(PrimitiveTypeCode typeCode)
+            {
+                if (typeCode == PrimitiveTypeCode.String) return valueReader.ReadSerializedString();
+                return string.Empty;
+            }
+            public string GetSZArrayType(string elementType) => "";
+            public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => "";
+            public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => "";
+            public string GetTypeFromSpecification(MetadataReader reader, object genericContext, TypeSpecificationHandle handle, byte rawTypeKind) => "";
+        }
+
+        /// <summary>
+        /// Get the TargetFrameworkAttribute parameter value from an <see cref="AssemblyDefinition"/>
+        /// </summary>
+        /// <param name="reader">The metadata reader</param>
+        /// <param name="assembly">The assembly definition</param>
+        /// <returns></returns>
+        private static string GetTargetFrameworkFromAssembly(MetadataReader reader, AssemblyDefinition assembly)
+        {
+            var customAttrs = assembly.GetCustomAttributes().Select(reader.GetCustomAttribute).Where(x => x.Constructor.Kind == HandleKind.MemberReference);
+            foreach (var attribute in customAttrs)
+            {
+                var memberRef = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                var container = memberRef.Parent;
+                var attributeTypeRef = reader.GetTypeReference((TypeReferenceHandle)container);
+                var attributeNameHandle = attributeTypeRef.Name;
+                var attributeName = reader.GetString(attributeNameHandle);
+                if (attributeName.Equals(nameof(TargetFrameworkAttribute)))
+                {
+                    return attribute.GetParameterValues(reader).FirstOrDefault();
+                }
+            }
+            return string.Empty;
         }
     }
 }

--- a/NUnit.Commander/NUnit.Commander/IO/TestRunnerLauncher.cs
+++ b/NUnit.Commander/NUnit.Commander/IO/TestRunnerLauncher.cs
@@ -196,11 +196,21 @@ namespace NUnit.Commander.IO
                     {
                         var nunitConsoleTestAssemblies = string.Join(" ", dotNetFrameworkTestAssemblies.Select(x => x.Key));
                         isSuccess = LaunchNUnitConsole(string.Join(" ", _options.NUnitConsoleArguments, nunitConsoleTestAssemblies));
+                        if (!isSuccess)
+                        {
+                            Console.WriteLine("Failed to launch NUnit console runner, aborting!");
+                            return false;
+                        }
                     }
                     if (dotNetCoreTestAssemblies.Any())
                     {
                         var dotNetTestAssemblies = string.Join(" ", dotNetCoreTestAssemblies.Select(x => x.Key));
                         isSuccess = LaunchDotNetTest(string.Join(" ", dotNetTestAssemblies, _options.DotNetTestArguments));
+                        if (!isSuccess)
+                        {
+                            Console.WriteLine("Failed to launch dotnet runner, aborting!");
+                            return false;
+                        }
                     }
                     //System.Threading.Thread.Sleep(500);
                     break;
@@ -299,7 +309,8 @@ namespace NUnit.Commander.IO
             // load all of the assemblies and inspect them
             foreach (var assemblyPath in runnerAssemblies.Split(" ", StringSplitOptions.RemoveEmptyEntries))
             {
-                assemblyMetadata.Add(assemblyPath, PortableExecutableHelper.GetAssemblyFrameworkType(assemblyPath));
+                var fullpath = assemblyPath;
+                assemblyMetadata.Add(fullpath, PortableExecutableHelper.GetAssemblyFrameworkType(fullpath));
             }
             OnScanCompleted?.Invoke();
             return assemblyMetadata;

--- a/NUnit.Commander/NUnit.Commander/NUnit.Commander.csproj
+++ b/NUnit.Commander/NUnit.Commander/NUnit.Commander.csproj
@@ -10,9 +10,9 @@
 		<PackageProjectUrl>https://github.com/replaysMike/NUnit.Extension.TestMonitor</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/replaysMike/NUnit.Extension.TestMonitor</RepositoryUrl>
 		<PackageTags>nunit commander real-time testing tests refactor software michael brown</PackageTags>
-		<AssemblyVersion>1.5.0.0</AssemblyVersion>
-		<FileVersion>1.5.0.0</FileVersion>
-		<Version>1.5.0</Version>
+		<AssemblyVersion>1.5.1.0</AssemblyVersion>
+		<FileVersion>1.5.1.0</FileVersion>
+		<Version>1.5.1</Version>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PublishSingleFile>true</PublishSingleFile>
 		<PublishReadyToRun>true</PublishReadyToRun>

--- a/NUnit.Commander/NUnit.Commander/Properties/launchSettings.json
+++ b/NUnit.Commander/NUnit.Commander/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "NUnit.Commander": {
-      "commandName": "Project",
-      "commandLineArgs": "--test-runner Auto --path=b:/gitrepo/provantagex/server/tools/NUnit --nunit-args=\"--noheader --noresult --workers=16 --where \\\"cat != ExcludeFakeCategory1\\\"\" --dotnet-args=\"--filter Name~Should_Pass3&TestCategory!=ExcludeFakeCategory1\" --test-assemblies=\"../../../../../DotNetFrameworkTests/bin/Debug/DotNetFrameworkTests.dll  ../../../../../DotNetCoreTests/bin/Debug/net5.0/DotNetCoreTests.dll\""
+      "commandName": "Project"
     }
   }
 }

--- a/NUnit.Commander/NUnit.Commander/Reporting/PerformanceLog.cs
+++ b/NUnit.Commander/NUnit.Commander/Reporting/PerformanceLog.cs
@@ -23,7 +23,6 @@ namespace NUnit.Commander.Reporting
 
         public void AddEntry(PerformanceType type, float value)
         {
-            System.Diagnostics.Debug.WriteLine($"{type}: {value}");
             _log[type].Add(new PerformanceEntry(value));
         }
 


### PR DESCRIPTION
 Loading via assembly.load is no longer ideal for .net core, so had to rewrite this to support MetadataReader which is more complex.